### PR TITLE
Specify dopamine-rl version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     install_requires=[
         'bz2file',
-        'dopamine-rl',
+        'dopamine-rl==3.0.1',
         'flask',
         'future',
         'gevent',


### PR DESCRIPTION
For `dopamine-rl > 3.0.1`, it depends on `tensorflow >= 2.2.0`. That is why install this custom version of tensor2tensor will automatically upgrade the tensorflow version while SV2P still requires and old version, as described in https://github.com/suraj-nair-1/lorel.
In addition, `dopamine-rl > 3.0.1` requires `flax` and `jax`, but I believe this custom version of tensor2tensor doesn't depend on them.
See https://github.com/google/dopamine/commit/ab567851d68a7ad1aa4811d87cd367f2ad2583a5
After this PR, the installation of this package won't be tricky anymore.